### PR TITLE
feat: 상담내역보고서 생성을 위한 특정 제목 상담내역 조회 API 연동

### DIFF
--- a/src/components/CounselingReport.tsx
+++ b/src/components/CounselingReport.tsx
@@ -20,11 +20,30 @@ interface Student {
   img: string;
 }
 
-interface CouncelingReportProps {
-  student: Student;
+interface ConsultationItem {
+  consultationId: number;
+  studentId: number;
+  teacherId: number;
+  date: string;
+  isPublicToSubject: boolean;
+  content: string;
+  nextPlan: string;
+  title: string;
+  subject: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
-const CouncelingReport: React.FC<CouncelingReportProps> = ({ student }) => {
+interface CouncelingReportProps {
+  student: Student;
+  data: ConsultationItem[];
+}
+
+const CouncelingReport: React.FC<CouncelingReportProps> = ({
+  student,
+  data,
+}) => {
   return (
     <MainContainer>
       <Header>
@@ -36,36 +55,23 @@ const CouncelingReport: React.FC<CouncelingReportProps> = ({ student }) => {
           <p>상담 내역 보고서</p>
         </TitleArea>
       </Header>
-      <DescriptionArea>
-        <Description>O월 O일자 상담 내역</Description>
-        <Line />
-      </DescriptionArea>
-      <CouncelingArea>
-        <CouncelingTitle>
-          <h3>제목: OOO</h3>
-          <p>담당자: ooo</p>
-        </CouncelingTitle>
-        <CouncelingContent>
-          Lorem ipsum dolor sit amet consectetur. Risus blandit enim diam
-          pellentesque et sodales sem facilisi lacus. Id tincidunt nec lorem
-          tincidunt porttitor. Vel pulvinar sociis varius fermentum pellentesque
-          neque mauris. Eu nisl volutpat ut gravida sagittis odio at. Faucibus
-          purus habitasse turpis proin leo viverra vitae blandit. Nisl velit
-          morbi viverra ut interdum. Mi fringilla nisi volutpat egestas id
-          tortor. Risus purus sit neque orci. Eu rhoncus porta mattis phasellus
-          et elit elit. Diam lorem in malesuada vestibulum. Auctor hac
-          sollicitudin donec justo interdum suscipit sed fames. Sem sit purus
-          elementum mattis felis arcu turpis mi. Viverra cras et a et proin
-          viverra magna vestibulum. Porttitor tempor volutpat neque vivamus.
-          Quam lorem massa dictum adipiscing gravida ut nisl. Malesuada dapibus
-          dignissim dui sed at et. Blandit enim ultricies et id mattis
-          consectetur ut metus. Tristique posuere nunc at vitae ultricies quis
-          velit quis sit. Egestas ut ultrices enim viverra morbi maecenas tortor
-          elementum. Feugiat vestibulum risus ac nibh lectus elit integer mi
-          est. Ut in sed volutpat ut nunc pulvinar hendrerit vulputate. Augue
-          massa malesuada nunc mauris pulvinar velit neque risus phasellus.
-        </CouncelingContent>
-      </CouncelingArea>
+      {data.map((consult: ConsultationItem) => (
+        <React.Fragment key={consult.consultationId}>
+          <DescriptionArea>
+            <Description>
+              {new Date(consult.date).toLocaleDateString("ko-KR")} 상담 내역
+            </Description>
+            <Line />
+          </DescriptionArea>
+          <CouncelingArea>
+            <CouncelingTitle>
+              <h3>제목: {consult.title}</h3>
+              <p>담당자: {consult.author}</p>
+            </CouncelingTitle>
+            <CouncelingContent>{consult.content}</CouncelingContent>
+          </CouncelingArea>
+        </React.Fragment>
+      ))}
     </MainContainer>
   );
 };

--- a/src/components/CounselingSearchTable.tsx
+++ b/src/components/CounselingSearchTable.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import {
+  BoardTable,
+  TableHeader,
+  TableRow,
+  TableCell,
+  TitleCell,
+} from "../page/CounselingPage.styled";
+
+interface CounselingItem {
+  consultationId: number;
+  studentId: number;
+  teacherId: number;
+  date: string;
+  isPublicToSubject: boolean;
+  content: string;
+  nextPlan: string;
+  title: string;
+  subject: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CounselingProps {
+  data: CounselingItem[];
+  onSelect: (counseling: CounselingItem) => void;
+}
+
+const CounselingSearchTable: React.FC<CounselingProps> = ({
+  data,
+  onSelect,
+}) => {
+  if (!data.length) return null;
+
+  return (
+    <BoardTable>
+      <thead>
+        <TableRow>
+          <TableHeader width="3rem">번호</TableHeader>
+          <TableHeader width="40rem">제목</TableHeader>
+          <TableHeader width="10rem">작성자</TableHeader>
+          <TableHeader width="5rem">담당과목</TableHeader>
+          <TableHeader width="13rem">상담일자</TableHeader>
+        </TableRow>
+      </thead>
+      <tbody>
+        {data.map((post, index) => (
+          <TableRow
+            key={post.consultationId}
+            onClick={() => onSelect(post)}
+            style={{ cursor: "pointer" }}
+          >
+            <TableCell isBold>{index + 1}</TableCell>
+            <TitleCell>{post.title}</TitleCell>
+            <TableCell>{post.author}</TableCell>
+            <TableCell>{post.subject}</TableCell>
+            <TableCell>{new Date(post.date).toLocaleDateString()}</TableCell>
+          </TableRow>
+        ))}
+      </tbody>
+    </BoardTable>
+  );
+};
+
+export default CounselingSearchTable;

--- a/src/components/ScoreReport.styled.ts
+++ b/src/components/ScoreReport.styled.ts
@@ -12,7 +12,7 @@ export const MainContainer = styled.div`
 
 export const Header = styled.header`
   width: 54rem;
-  height: 6.75rem;
+  height: 5.1rem;
   margin-top: 2.25rem;
   border-radius: 1.25rem;
   border: 1px solid #000;

--- a/src/page/ReportPage.styled.ts
+++ b/src/page/ReportPage.styled.ts
@@ -177,3 +177,9 @@ export const SaveButton = styled.button`
   background: none;
   cursor: pointer;
 `;
+
+export const SelectedArea = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+`;


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- ReportPage에서 상담내역보고서 생성을 위한 특정 제목 상담내역 조회 API 연동
- 조회 시 상담 내역을 선택할 수 있는 테이블 컴포넌트 구현  
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #109
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
  
## 📌 추가 사항  
