### PR TITLE
fix: 특정학생의 성적관리(과목별) 오류 수정

### DIFF
--- a/src/page/GradePage.tsx
+++ b/src/page/GradePage.tsx
@@ -231,6 +231,15 @@ const GradePage: React.FC = () => {
     setIsEditing(false);
   };
 
+  const parseSemester = (semesterStr: string) => {
+    const match = semesterStr.match(/(\d)학년 (\d)학기/);
+    if (!match) return { schoolYear: 0, semester: 0 };
+    return {
+      schoolYear: Number(match[1]),
+      semester: Number(match[2]),
+    };
+  };
+
   const handleSave = async () => {
     if (!selectedStudent) return;
 
@@ -252,41 +261,39 @@ const GradePage: React.FC = () => {
               updatedAt: found.updatedAt,
             });
           }
-        } else {
-          if (g.score !== undefined) {
-            postPayload.push({
-              subject: g.subject!,
-              schoolYear: Number(selectedGrade),
-              semester: Number(selectedSemester),
-              score: Number(g.score),
-            });
-          }
+        } else if (g.score !== undefined) {
+          postPayload.push({
+            subject: g.subject!,
+            schoolYear: Number(selectedGrade),
+            semester: Number(selectedSemester),
+            score: Number(g.score),
+          });
         }
       } else {
+        const { schoolYear, semester } = parseSemester(g.semester ?? "");
         const found = initiallyFetchedGrades.find(
           (f) =>
             f.subject === selectedSubject &&
-            f.schoolYear === Number(g.semester?.[0]) &&
-            f.semester === Number(g.semester?.[4])
+            f.schoolYear === schoolYear &&
+            f.semester === semester
         );
         if (found) {
           if (found.score !== g.score && g.score !== undefined) {
             patchPayload.push({
               subject: selectedSubject,
-              schoolYear: Number(g.semester?.[0]),
-              semester: Number(g.semester?.[4]),
+              schoolYear,
+              semester,
               score: Number(g.score),
+              updatedAt: found.updatedAt,
             });
           }
-        } else {
-          if (g.score !== undefined) {
-            postPayload.push({
-              subject: selectedSubject,
-              schoolYear: Number(g.semester?.[0]),
-              semester: Number(g.semester?.[4]),
-              score: Number(g.score),
-            });
-          }
+        } else if (g.score !== undefined) {
+          postPayload.push({
+            subject: selectedSubject,
+            schoolYear,
+            semester,
+            score: Number(g.score),
+          });
         }
       }
     }


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- 과목별 저장 시 문자열 인덱싱 방식으로 학기 정보를 추출하다가 공백이 추출되어 semester=0이라는 잘못된 값이 생성됨 
-> API 404 오류가 발생
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #201 
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>
